### PR TITLE
Using looping noise sound when LFSR(x) loops

### DIFF
--- a/src/IO/AudioController.cpp
+++ b/src/IO/AudioController.cpp
@@ -77,12 +77,14 @@ void AudioController::init() {
     uint16_t lfsr7 = 0x7F;
     uint16_t lfsr15 = 0x7FFF;
     auto xor_res = 0;
-    for(auto i = 0; i < NOISE_BUFFER_SIZE; i++) {
+    for(auto i = 0; i < LFSR15_BUFFER_SIZE; i++) {
         xor_res = (lfsr15 ^ (lfsr15 >> 1)) & 1;
         lfsr15 >>= 1;
         lfsr15 |= xor_res << 14;
-        noise15bit[i] = lfsr15 & 1 ? 0 : (char)0xFF;
+        noise15bit[i] = lfsr15 & 1 ? 0 : (char) 0xFF;
+    }
 
+    for(auto i = 0; i < LFSR7_BUFFER_SIZE; i++) {
         xor_res = (lfsr7 ^ (lfsr7 >> 1)) & 1;
         lfsr7 >>= 1;
         lfsr7 |= xor_res << 6;
@@ -177,7 +179,11 @@ void AudioController::setVolume(int source, float volume) {
 }
 
 void AudioController::playNoise(int source, bool is_7_bit_mode, ALsizei frequency, float volume) {
-    playSound(source, is_7_bit_mode ? noise7bit : noise15bit, NOISE_BUFFER_SIZE, frequency, volume);
+    if(is_7_bit_mode) {
+        playSound(source, noise7bit, LFSR7_BUFFER_SIZE, frequency, volume);
+    } else {
+        playSound(source, noise15bit, LFSR15_BUFFER_SIZE, frequency, volume);
+    }
 }
 
 void AudioController::stopSound() {

--- a/src/IO/AudioController.h
+++ b/src/IO/AudioController.h
@@ -33,7 +33,8 @@ public:
 private:
     const static int N_SOURCES = 4;
     const static int SQUARE_SAMPLE_RATE = 32;
-    const static int NOISE_BUFFER_SIZE = 100000;
+    const static int LFSR7_BUFFER_SIZE = 0x7F;
+    const static int LFSR15_BUFFER_SIZE = 0x7FFF;
 
     ALCdevice* device;
     ALCcontext* context;
@@ -43,8 +44,8 @@ private:
     ALuint buffers[N_SOURCES];
     ALuint sources[N_SOURCES];
 
-    unsigned char noise15bit[NOISE_BUFFER_SIZE];
-    unsigned char noise7bit[NOISE_BUFFER_SIZE];
+    unsigned char noise15bit[LFSR15_BUFFER_SIZE];
+    unsigned char noise7bit[LFSR7_BUFFER_SIZE];
     unsigned char duties[N_SOURCES][SQUARE_SAMPLE_RATE];
 
     void stopSource(int source);

--- a/tests/audio_test.cpp
+++ b/tests/audio_test.cpp
@@ -96,3 +96,23 @@ TEST(AUDIO, PLAY_NOISE) {
     }
     a.stopSound();
 }
+
+TEST(AUDIO, GENERATE_NOISE) {
+    uint16_t lfsr7 = 0x7F;
+    uint16_t lfsr15 = 0x7FFF;
+    auto xor_res = 0;
+    for(auto i = 0; i < 32767; i++) {
+        xor_res = (lfsr15 ^ (lfsr15 >> 1)) & 1;
+        lfsr15 >>= 1;
+        lfsr15 |= xor_res << 14;
+    }
+
+    for(auto i = 0; i < 127; i++) {
+        xor_res = (lfsr7 ^ (lfsr7 >> 1)) & 1;
+        lfsr7 >>= 1;
+        lfsr7 |= xor_res << 6;
+    }
+
+    ASSERT_EQ(0x7F, lfsr7);
+    ASSERT_EQ(0x7FFF, lfsr15);
+}


### PR DESCRIPTION
Since the `LFSR(x)` function which is used to generate pseudo-random sound loops at x = 0x7F (W = 1) and x = 0x7FFF (W = 0), the generated sound is looped at these points, instead of looping at x = 100000